### PR TITLE
Fix rounding errors in displayBytes. Simplify displayBytes.

### DIFF
--- a/devtools/display.js
+++ b/devtools/display.js
@@ -12,32 +12,13 @@ function displayResult(page) {
 }
 
 function displayBytes(bytes) {
-	var bytesInt = parseInt(bytes);
-	var total_mb = 0;
-	var total_kb = 0;
-	var total_b  = 0;
+	var prefixes = ["","Ki","Mi","Gi","Ti","Pi","Ei"];
+	var value    = parseInt(bytes);
 
-	while(bytesInt >= 1048576) {
-		total_mb += 1;
-		bytesInt -= 1048576;
-	}
+	for (var prefix = 0; value >= 1023.995 && prefix < prefixes.length - 1; ++prefix) value /= 1024;
 
-	while(bytesInt >= 1024) {
-		total_kb += 1;
-		bytesInt -= 1024;
-	}
-
-	total_b = bytesInt;
-
-	if(total_mb == 0 && total_kb == 0) {
-		return (total_b.toString() + " bytes");
-	}
-	else if(total_mb == 0 && total_kb != 0) {
-		return (total_kb.toString() + '.' + parseInt((total_b / 1024) * 100).toString() + " KB")
-	}
-	else {
-		return (total_mb.toString() + '.' + parseInt(((total_kb * 1024 + total_b) / 1048576) * 100).toString() + " MB")
-	}
+	if (0 != prefix) value = value.toFixed(2);
+	return value + " " + prefixes[prefix] + "B";
 }
 
 function displayPercentChange(originalSize, transformedSize) {


### PR DESCRIPTION
`displayBytes` gave incorrect output in cases close to the mebibyte boundary.
```
// Old way
displayBytes(1048575);
=> "1023.99 KB"
```
```
// New way
displayBytes(1048575);
=> "1.00 MiB"
```
This is because 1048575 bytes is equal to 1023.9990234375 kibibytes. Displaying this as 1023.99 KiB is inaccurate because it truncates the remaining decimal places instead of properly rounding them to 1024.00 KiB, which is better displayed as 1.00 MiB.

This pull request fixes these rounding cases and simplifies `displayBytes`.