### PR TITLE
Updating to use the updated A2 headers

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,10 +10,10 @@ beforeSendCallback = function(details) {
 		details.requestHeaders.push({name: 'x-im-piez', value: 'on'});
 		details.requestHeaders.push({name: 'x-akamai-ro-piez', value: 'on'});
 		details.requestHeaders.push({name: 'x-akamai-rua-debug', value: 'on'});
-		details.requestHeaders.push({name: 'pragma', value: 'akamai-x-ro-trace x-akamai-cpi-trace'});
+		details.requestHeaders.push({name: 'pragma', value: 'akamai-x-ro-trace x-akamai-a2-trace'});
 	}
 	if(details.url.indexOf('https') != -1 && details.frameId === 0 && urlMatch.test(details.url)) {
-		details.requestHeaders.push({name: 'x-akamai-rua-debug', value: ''}, {name:'pragma', value: 'akamai-x-ro-trace x-akamai-cpi-trace'});
+		details.requestHeaders.push({name: 'x-akamai-rua-debug', value: ''}, {name:'pragma', value: 'akamai-x-ro-trace x-akamai-a2-trace'});
 	}
 	return {requestHeaders: details.requestHeaders};
 };

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Piez",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "manifest_version": 2,
   "description" : "Piez is a developer tool to show optimizations made by Akamai Image Manager and Adaptive Acceleration.",
   "icons": { "16": "icons/16x16.png", "19": "icons/19x19.png", "38": "icons/38x38.png", "48": "icons/48x48.png", "128": "icons/128x128.png" },

--- a/tests/a2-parse-test.js
+++ b/tests/a2-parse-test.js
@@ -173,7 +173,7 @@ QUnit.module('Parsing resources from HAR', {
                     response: {
                         status: 200,
                         headers: [
-                            {name: 'x-akamai-cpi-enabled', value: 'true'},
+                            {name: 'x-akamai-a2-enabled', value: 'true'},
                             {name: 'x-akamai-rua-debug-policy-version', value: '1'}
                         ]
                     }
@@ -190,7 +190,7 @@ QUnit.test('A2 Status and policy version', function(assert) {
     assert.ok(this.page.A2Policy, 'Policy value given');
 
     this.har.entries[0].response.headers = [
-        {name: 'x-akamai-cpi-enabled', value: 'false'},
+        {name: 'x-akamai-a2-enabled', value: 'false'},
         {name: 'x-akamai-rua-debug-policy-version', value: ''}
     ];
     this.page = new Page();


### PR DESCRIPTION
The header values changed after the rebranding from CPI to A2.  This changes the header values.